### PR TITLE
fix(learn): backslashes in description & hint text

### DIFF
--- a/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/split-a-character-string-based-on-change-of-character.md
+++ b/curriculum/challenges/english/10-coding-interview-prep/rosetta-code/split-a-character-string-based-on-change-of-character.md
@@ -11,13 +11,13 @@ dashedName: split-a-character-string-based-on-change-of-character
 Split a (character) string into comma (plus a blank) delimited strings based on a change of character (left to right). Blanks should be treated as any other character (except they are problematic to display clearly). The same applies to commas. For instance, the string:
 
 <pre>
-"gHHH5YY++///\"
+"gHHH5YY++///\\"
 </pre>
 
 should be split as:
 
 <pre>
-["g", "HHH", "5", "YY", "++", "///", "\" ];
+["g", "HHH", "5", "YY", "++", "///", "\\" ];
 </pre>
 
 # --hints--
@@ -80,7 +80,7 @@ assert.deepEqual(split('sssmmmaaammmaaat'), [
 ]);
 ```
 
-`split("gHHH5YY++///\")` should return `["g", "HHH", "5", "YY", "++", "///", "\\"]`.
+`split("gHHH5YY++///\\")` should return `["g", "HHH", "5", "YY", "++", "///", "\\"]`.
 
 ```js
 assert.deepEqual(split('gHHH5YY++///\\'), [


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)
- [x] My pull request targets the `master` branch of freeCodeCamp.
- [x] All the files I changed are in the same world language, for example: only English changes, or only Chinese changes, etc.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Correct example code in description and last hint text to match the last assertion test's actual and expected inputs.  The string input with a single backslash throws an unterminated string constant error (single backslash starts a regex).  No change to last assertion test as it was written correctly with a double backslash and passing as expected.

